### PR TITLE
Fix emcc call

### DIFF
--- a/webidl/Generate.hx
+++ b/webidl/Generate.hx
@@ -405,6 +405,7 @@ template<typename T> pref<T> *_alloc_const( const T *value ) {
 		var emSdk = Sys.getEnv("EMSCRIPTEN");
 		if( emSdk == null )
 			throw "Missing EMSCRIPTEN environment variable. Install emscripten";
+		var emcc = emSdk + "/emcc";
 
 		// build sources BC files
 		var outFiles = [];
@@ -412,8 +413,7 @@ template<typename T> pref<T> *_alloc_const( const T *value ) {
 		for( cfile in sources ) {
 			var out = cfile.substr(0, -4) + ".bc";
 			var args = params.concat(["-c", cfile, "-o", out]);
-			args.unshift(emSdk + "/emcc.py");
-			command("python", args);
+			command( emcc, args);
 			outFiles.push(out);
 		}
 
@@ -426,10 +426,10 @@ template<typename T> pref<T> *_alloc_const( const T *value ) {
 		]);
 		var output = "SOURCES = " + outFiles.join(" ") + "\n";
 		output += "all:\n";
-		output += "\tpython \"$(EMSCRIPTEN)/emcc.py\" $(SOURCES) " + args.join(" ");
+		output += "\t"+emcc+" $(SOURCES) " + args.join(" ");
 		sys.io.File.saveContent(tmp, output);
 		command("make", ["-f", tmp]);
-		sys.FileSystem.deleteFile(tmp);
+		//sys.FileSystem.deleteFile(tmp);
 	}
 
 

--- a/webidl/Generate.hx
+++ b/webidl/Generate.hx
@@ -429,7 +429,7 @@ template<typename T> pref<T> *_alloc_const( const T *value ) {
 		output += "\t"+emcc+" $(SOURCES) " + args.join(" ");
 		sys.io.File.saveContent(tmp, output);
 		command("make", ["-f", tmp]);
-		//sys.FileSystem.deleteFile(tmp);
+		sys.FileSystem.deleteFile(tmp);
 	}
 
 


### PR DESCRIPTION
Call `$EMSCRIPTEN/emcc` instead of `python EMSCRIPTEN)/emcc.py` otherwise the build fails when python3 is set as active version (emcc.py needs python 2).