### PR TITLE
fix webidl.Types.Any on hl

### DIFF
--- a/webidl/Types.hx
+++ b/webidl/Types.hx
@@ -3,7 +3,7 @@ package webidl;
 abstract Ref(#if hl hl.Bytes #else Dynamic #end) {
 }
 
-abstract Any(Dynamic) {
+abstract Any(#if hl hl.Bytes #else Dynamic #end) {
 }
 
 abstract VoidPtr(#if hl hl.Bytes #else Dynamic #end) {


### PR DESCRIPTION
the glue generator generates _BYTES for any, so it has to be hl.Bytes on HL

this looks release-worthy