### PR TITLE
Modularize JavaScript Output and Update Binder

### DIFF
--- a/sample/Sample.hx
+++ b/sample/Sample.hx
@@ -1,9 +1,19 @@
 import SampleModule.Point;
+import SampleModule.Js as SampleModuleJs;
 
 class Sample {
 
 	public static function main() {
-		var p1 = new Point();
+		#if js
+		SampleModuleJs.init(startApp);
+		#else
+		startApp();
+		#end
+	}
+
+
+	public static function startApp() {
+		var p1 = new Point();		
 		p1.x = 4;
 		p1.y = 5;
 		var p2 = new Point(7,8);
@@ -13,5 +23,4 @@ class Sample {
 		p2.delete();
 		p.delete();
 	}
-	
 }

--- a/sample/Sample.hx
+++ b/sample/Sample.hx
@@ -1,16 +1,11 @@
 import SampleModule.Point;
-import SampleModule.Js as SampleModuleJs;
+import SampleModule.Init as SampleModuleInit;
 
 class Sample {
 
 	public static function main() {
-		#if js
-		SampleModuleJs.init(startApp);
-		#else
-		startApp();
-		#end
+		SampleModuleInit.init(startApp);
 	}
-
 
 	public static function startApp() {
 		var p1 = new Point();		

--- a/webidl/Generate.hx
+++ b/webidl/Generate.hx
@@ -420,7 +420,7 @@ template<typename T> pref<T> *_alloc_const( const T *value ) {
 		// link : because too many files, generate Makefile
 		var tmp = "Makefile.tmp";
 		var args = params.concat([
-			"-s", 'EXPORT_NAME="\'$lib\'"',
+			"-s", 'EXPORT_NAME="\'$lib\'"', "-s", "MODULARIZE=1",
 			"--memory-init-file", "0",
 			"-o", '$lib.js'
 		]);

--- a/webidl/Module.hx
+++ b/webidl/Module.hx
@@ -1,11 +1,11 @@
 package webidl;
 
+#if macro
 import webidl.Data;
 import haxe.macro.Context;
 import haxe.macro.Expr;
 
 class Module {
-
 	var p : Position;
 	var hl : Bool;
 	var pack : Array<String>;
@@ -413,9 +413,17 @@ class Module {
 
 		// Add an init function for initializing the JS module
 		if (Context.defined("js")) {
-			types.push(macro class Js {
+			types.push(macro class Init {
 				public static function init(onReady:Void->Void) {
 					untyped __js__('${opts.nativeLib} = ${opts.nativeLib}().then(onReady)');
+				}
+			});
+
+		// For HL no initialization is required so execute the callback immediately
+		} else if (Context.defined("hl")) {
+			types.push(macro class Init {
+				public static function init(onReady:Void->Void) {
+					onReady();
 				}
 			});
 		}
@@ -433,5 +441,6 @@ class Module {
 	private static function capitalize(text:String) {
 		return text.charAt(0).toUpperCase() + text.substring(1);
 	}
-
 }
+
+#end

--- a/webidl/Module.hx
+++ b/webidl/Module.hx
@@ -288,7 +288,7 @@ class Module {
 								if( f.access == null ) f.access = [];
 								switch( f.kind ) {
 								case FFun(df):
-									var call = "_eb_" + switch( m.params[1].expr ) { case EConst(CString(name)): name; default: throw "!"; };
+									var call = opts.nativeLib + "._eb_" + switch( m.params[1].expr ) { case EConst(CString(name)): name; default: throw "!"; };
 									var args : Array<Expr> = [for( a in df.args ) { expr : EConst(CIdent(a.name)), pos : p }];
 									if( f.access.indexOf(AStatic) < 0 )
 										args.unshift(macro this);
@@ -410,6 +410,16 @@ class Module {
 		var module = Context.getLocalModule();
 		var types = buildTypes(opts, Context.defined("hl"));
 		if (types == null) return macro : Void;
+
+		// Add an init function for initializing the JS module
+		if (Context.defined("js")) {
+			types.push(macro class Js {
+				public static function init(onReady:Void->Void) {
+					untyped __js__('${opts.nativeLib} = ${opts.nativeLib}().then(onReady)');
+				}
+			});
+		}
+
 		Context.defineModule(module, types);
 		Context.registerModuleDependency(module, file);
 


### PR DESCRIPTION
Modularize the JavaScript output and update the bindings to match. This
has two important advantages:

* Modularizing the JS output namespaces the classes to prevent name
collisions when including multiple libraries.
* The JS module has a callback that is called when the runtime is ready
that fixes a problem where your code tries to use the Emscripten classes
before they are initialized.

This also includes an update to the sample to use the JS init callback. The sample would actually fail for me without this patch because the point class was not initialized by the time that the sample code ran.