### PR TITLE
fix sample compile

### DIFF
--- a/sample/Makefile
+++ b/sample/Makefile
@@ -1,4 +1,4 @@
-all:
+all: hl js
 
 libpoint.cpp:
 	haxe -lib webidl --macro "SampleModule.buildLibCpp()"
@@ -16,7 +16,7 @@ HLPATH = /path/to/hl
 endif
 
 libpoint.hdll: libpoint.cpp
-	$(CC) -o libpoint.hdll -shared -Wall -O3 -I . -I $(HLPATH) libpoint.cpp point.cpp -lstdc++ -lhl
+	$(CC) -o libpoint.hdll -shared -fPIC -Wall -O3 -I . -I $(HLPATH) libpoint.cpp point.cpp -lstdc++ -lhl
 
 libpoint_win: libpoint.cpp
 	cl /olibpoint.hdll /LD /EHsc /I $(HLPATH) /DYNAMICBASE libhl.lib libpoint.cpp point.cpp


### PR DESCRIPTION
In sample directory, `make all` didn't work well.

This was bacause 
* `all` target in `Makefile` has no dependency and no commands, so `make all` did nothing
* in generating `libpoint.hdll`, the option `-fPIC` was missing
* sample codes may not catch up with the latest library codes

I fixed them